### PR TITLE
Fix version of package defined

### DIFF
--- a/cookbooks/le/recipes/install.rb
+++ b/cookbooks/le/recipes/install.rb
@@ -23,7 +23,7 @@ execute "ebuild le-0.0.0.ebuild digest" do
 end
 
 package 'dev-util/le' do
-  version node['0.0.0']
+  version '0.0.0'
   action :install
 end
 


### PR DESCRIPTION
This is obviously a typo. In fact, it results in version being `nil` and so Chef starts looking in `emerge` to determine package version, that results in error.

This is also obviously not by design and upper lines obviously prepare 0.0.0 versioned overlay.
