### PR TITLE
Use node names in node registration

### DIFF
--- a/cookbooks/le/recipes/configure.rb
+++ b/cookbooks/le/recipes/configure.rb
@@ -4,7 +4,7 @@
 #
 
 execute "le register --account-key" do
-  command "le register --account-key #{node[:le_api_key]}"
+  command "le register --account-key #{node[:le_api_key]} --name #{node[:name]}"
   action :run
   not_if { File.exists?('/etc/le/config') } 
 end


### PR DESCRIPTION
This makes log entries a lot prettier. Otherwise they hold hostnames, which are ips on engineyard.
